### PR TITLE
Fixed issue with handling falsy values to return 0

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -11,6 +11,7 @@ import {compactInteger, formatNumber} from 'humanize-plus';
 
 function humaniseNumber(inNumber: number|string, options: HumanizeOptions = {}){
     let origNumber: number = parseFloat('' + inNumber);
+    // if given number is 0 or a falsy value it should return 0
     if(origNumber == 0 || !origNumber){
         return '0';
     }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -11,7 +11,7 @@ import {compactInteger, formatNumber} from 'humanize-plus';
 
 function humaniseNumber(inNumber: number|string, options: HumanizeOptions = {}){
     let origNumber: number = parseFloat('' + inNumber);
-    if(origNumber == 0){
+    if(origNumber == 0 || !origNumber){
         return '0';
     }
     var negative = false;


### PR DESCRIPTION
When null or any other falsy value is passed into the function it will return 0 now.